### PR TITLE
Fix the #6 nomisma.org schema extraction error

### DIFF
--- a/build/example-config.yml
+++ b/build/example-config.yml
@@ -55,6 +55,10 @@ largeQueryTimeout: 0
 smallQueryTimeout: 0
 delayOnFailure: 0
 waitingTimeForEndpoint: 60
+# MIME type for the HTTP Accept header of SPARQL result requests.
+# Leave empty for the SPARQL client default; set one of:
+# application/sparql-results+json | application/sparql-results+xml | text/csv
+acceptHeaderForSparqlResults: ""
 enableLogging: true
 logNoClassesForProperty: sourcesOnly
 crossCheckTargetClassesOnNonLiteralPropertyObjectCheckFailure: false

--- a/src/main/java/lv/lumii/obis/rest/app/SchemaExtractorRequestBuilder.java
+++ b/src/main/java/lv/lumii/obis/rest/app/SchemaExtractorRequestBuilder.java
@@ -78,6 +78,7 @@ public class SchemaExtractorRequestBuilder {
         requestDto.setWaitingTimeForEndpoint(request.getWaitingTimeForEndpoint());
         requestDto.setLogNoClassesForProperty(Enums.getIfPresent(SchemaExtractorRequestDto.NoClassesLoggingOptions.class, request.getLogNoClassesForProperty().name()).orNull());
         requestDto.setCrossCheckTargetClassesOnNonLiteralPropertyObjectCheckFailure(request.getCrossCheckTargetClassesOnNonLiteralPropertyObjectCheckFailure());
+        requestDto.setAcceptHeaderForSparqlResults(request.getAcceptHeaderForSparqlResults());
         return requestDto;
     }
 

--- a/src/main/java/lv/lumii/obis/rest/app/SchemaExtractorRequestNew.java
+++ b/src/main/java/lv/lumii/obis/rest/app/SchemaExtractorRequestNew.java
@@ -135,6 +135,13 @@ public class SchemaExtractorRequestNew {
     @ApiParam(hidden = true, access = "239", value = "The level of logging when the property does not have associated classes", defaultValue = "sourcesOnly", required = true)
     private NoClassesLoggingOptions logNoClassesForProperty;
 
+    @ApiParam(access = "234",
+            value = "MIME type sent in the HTTP Accept header for SPARQL query results. Leave empty to use the SPARQL client default content negotiation. " +
+                    "Set a value if an endpoint requires a specific format (e.g., nomisma.org needs application/sparql-results+json)",
+            allowableValues = "application/sparql-results+json,application/sparql-results+xml,text/csv",
+            allowEmptyValue = true)
+    private String acceptHeaderForSparqlResults;
+
     public Boolean getCalculateSubClassRelations() {
         if (calculateSubClassRelations == null) {
             calculateSubClassRelations = Boolean.TRUE;

--- a/src/main/java/lv/lumii/obis/schema/services/common/SparqlEndpointProcessor.java
+++ b/src/main/java/lv/lumii/obis/schema/services/common/SparqlEndpointProcessor.java
@@ -20,6 +20,7 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 
+import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.apache.jena.sparql.exec.http.QuerySendMode;
@@ -219,7 +220,8 @@ public class SparqlEndpointProcessor {
     }
 
     private QueryExecutionHTTP getQueryExecutor(@Nonnull String endpointUrl, @Nullable String graphName, @Nonnull String query, boolean isPostMethod, @Nullable Long timeout) {
-        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.create().endpoint(endpointUrl).queryString(query);
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.create().endpoint(endpointUrl).queryString(query)
+                .acceptHeader(WebContent.contentTypeResultsJSON);
         if (StringUtils.isNotEmpty(graphName)) {
             builder = builder.addDefaultGraphURI(graphName);
         }

--- a/src/main/java/lv/lumii/obis/schema/services/common/SparqlEndpointProcessor.java
+++ b/src/main/java/lv/lumii/obis/schema/services/common/SparqlEndpointProcessor.java
@@ -20,7 +20,6 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 
-import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.apache.jena.sparql.exec.http.QuerySendMode;
@@ -45,7 +44,7 @@ public class SparqlEndpointProcessor {
     public QueryResponse read(@Nonnull SchemaExtractorRequestDto request, @Nonnull SparqlQueryBuilder queryBuilder) {
         Long timeout = calculateTimeout(request, queryBuilder);
         return read(new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.getEnableLogging(),
-                request.getPostMethod(), timeout, request.getDelayOnFailure(), request.getWaitingTimeForEndpoint()), queryBuilder, true);
+                request.getPostMethod(), timeout, request.getDelayOnFailure(), request.getWaitingTimeForEndpoint(), request.getAcceptHeaderForSparqlResults()), queryBuilder, true);
     }
 
     public boolean checkEndpointHealthAndStopExecutionOnError(@Nonnull SparqlEndpointConfig request, boolean applyWaiting) {
@@ -96,7 +95,7 @@ public class SparqlEndpointProcessor {
 
     public boolean checkEndpointHealthQuery(@Nonnull SparqlEndpointConfig request) {
         SparqlQueryBuilder queryBuilder = new SparqlQueryBuilder(ENDPOINT_HEALTH_CHECK.getSparqlQuery(), ENDPOINT_HEALTH_CHECK);
-        QueryResponse response = read(new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.isEnableLogging(), request.isPostRequest(), null, null, null), queryBuilder, false);
+        QueryResponse response = read(new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.isEnableLogging(), request.isPostRequest(), null, null, null, request.getAcceptHeaderForSparqlResults()), queryBuilder, false);
         return !response.hasErrors() && !response.getResults().isEmpty();
     }
 
@@ -135,7 +134,7 @@ public class SparqlEndpointProcessor {
         QueryResponse response = new QueryResponse();
         List<QueryResult> queryResults = null;
         ResultSet resultSet;
-        QueryExecutionHTTP queryExecutor = getQueryExecutor(request.getEndpointUrl(), request.getGraphName(), sparqlQuery, request.isPostRequest(), timeout);
+        QueryExecutionHTTP queryExecutor = getQueryExecutor(request.getEndpointUrl(), request.getGraphName(), sparqlQuery, request.isPostRequest(), timeout, request.getAcceptHeaderForSparqlResults());
         try {
             resultSet = queryExecutor.execSelect();
             if (attempt > 1) {
@@ -219,9 +218,13 @@ public class SparqlEndpointProcessor {
         queryResults.add(queryResult);
     }
 
-    private QueryExecutionHTTP getQueryExecutor(@Nonnull String endpointUrl, @Nullable String graphName, @Nonnull String query, boolean isPostMethod, @Nullable Long timeout) {
-        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.create().endpoint(endpointUrl).queryString(query)
-                .acceptHeader(WebContent.contentTypeResultsJSON);
+    private QueryExecutionHTTP getQueryExecutor(@Nonnull String endpointUrl, @Nullable String graphName, @Nonnull String query, boolean isPostMethod,
+                                                @Nullable Long timeout, @Nullable String acceptHeaderForSparqlResults) {
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.create().endpoint(endpointUrl).queryString(query);
+        // If no MIME type is configured, leave the Accept header unset so the SPARQL client uses its default content negotiation.
+        if (StringUtils.isNotEmpty(acceptHeaderForSparqlResults)) {
+            builder = builder.acceptHeader(acceptHeaderForSparqlResults);
+        }
         if (StringUtils.isNotEmpty(graphName)) {
             builder = builder.addDefaultGraphURI(graphName);
         }
@@ -259,8 +262,9 @@ public class SparqlEndpointProcessor {
 
     @Nonnull
     public List<QueryResult> read(@Nonnull SchemaExtractorRequestDto request, @Nonnull String queryName, @Nonnull String sparqlQuery) {
-        return read(new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.getEnableLogging(), request.getPostMethod(), null),
-                queryName, sparqlQuery);
+        SparqlEndpointConfig config = new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.getEnableLogging(), request.getPostMethod(), null);
+        config.setAcceptHeaderForSparqlResults(request.getAcceptHeaderForSparqlResults());
+        return read(config, queryName, sparqlQuery);
     }
 
     @Nonnull

--- a/src/main/java/lv/lumii/obis/schema/services/common/dto/SparqlEndpointConfig.java
+++ b/src/main/java/lv/lumii/obis/schema/services/common/dto/SparqlEndpointConfig.java
@@ -16,8 +16,11 @@ public class SparqlEndpointConfig {
     private Long delayOnFailure;
     private Long waitingTimeForEndpoint;
 
+    // MIME type for the HTTP Accept header; null/empty means use the SPARQL client default.
+    private String acceptHeaderForSparqlResults;
+
     public SparqlEndpointConfig(String correlationId, String endpointUrl, String graphName, boolean enableLogging, boolean isPostRequest,
-                                Long timeout, Long delayOnFailure, Long waitingTimeForEndpoint) {
+                                Long timeout, Long delayOnFailure, Long waitingTimeForEndpoint, String acceptHeaderForSparqlResults) {
         this.correlationId = correlationId;
         this.endpointUrl = endpointUrl;
         this.graphName = graphName;
@@ -26,6 +29,7 @@ public class SparqlEndpointConfig {
         this.timeout = timeout;
         this.delayOnFailure = delayOnFailure;
         this.waitingTimeForEndpoint = waitingTimeForEndpoint;
+        this.acceptHeaderForSparqlResults = acceptHeaderForSparqlResults;
     }
 
     public SparqlEndpointConfig(String correlationId, String endpointUrl, String graphName, boolean enableLogging,

--- a/src/main/java/lv/lumii/obis/schema/services/extractor/dto/SchemaExtractorRequestDto.java
+++ b/src/main/java/lv/lumii/obis/schema/services/extractor/dto/SchemaExtractorRequestDto.java
@@ -102,6 +102,10 @@ public class SchemaExtractorRequestDto {
     private Long delayOnFailure;
     private Long waitingTimeForEndpoint;
 
+    // MIME type sent in the HTTP Accept header for SPARQL query results.
+    // If null/empty, Jena's default Accept header is used (default behavior).
+    private String acceptHeaderForSparqlResults;
+
     private Boolean enableLogging;
 
     private NoClassesLoggingOptions logNoClassesForProperty;

--- a/src/main/java/lv/lumii/obis/schema/services/extractor/v2/SchemaExtractor.java
+++ b/src/main/java/lv/lumii/obis/schema/services/extractor/v2/SchemaExtractor.java
@@ -93,6 +93,7 @@ public class SchemaExtractor {
     protected void validateEndpointHealth(@Nonnull SchemaExtractorRequestDto request) {
         // validate GET health check query
         SparqlEndpointConfig requestConfig = new SparqlEndpointConfig(request.getCorrelationId(), request.getEndpointUrl(), request.getGraphName(), request.getEnableLogging(), false, null);
+        requestConfig.setAcceptHeaderForSparqlResults(request.getAcceptHeaderForSparqlResults());
         boolean isEndpointHealthy = sparqlEndpointProcessor.checkEndpointHealthQuery(requestConfig);
         if (isEndpointHealthy) {
             request.setPostMethod(Boolean.FALSE);


### PR DESCRIPTION
This PR fixes the #6 nomisma.org schema extraction error by introducing an optional parameter that allows a user to specify the MIME type (e.g. `application/sparql-results+json`) to use in the Accept: header sent to the SPARQL endpoint.

If the parameter is not specified, the extractor works as before.

P.S. I hope it is useful even if you can't merge it directly.